### PR TITLE
 Issue 1 - Fixing Revision Query String from "_rev" to "rev"

### DIFF
--- a/lib/sync_gateway.js
+++ b/lib/sync_gateway.js
@@ -83,7 +83,7 @@ SyncGateway.prototype.post = function(doc) {
 
 SyncGateway.prototype.put = function(doc) {
   var options = {
-    uri: '/' + doc._id + (doc._rev?'?_rev='+doc._rev:''),
+    uri: '/' + doc._id + (doc._rev?'?rev='+doc._rev:''),
     body: doc
   };
 
@@ -92,7 +92,7 @@ SyncGateway.prototype.put = function(doc) {
 
 SyncGateway.prototype.delete = function(doc) {
   var options = {
-    uri: '/' + doc._id + '?_rev='+ doc._rev
+    uri: '/' + doc._id + '?rev='+ doc._rev
   };
 
   return jsonRequest.delete(options);


### PR DESCRIPTION
As indicated by sync-gateway official documentation, the revision query string should be "rev" instead of "_rev". This is the cause of error "409 Document Exist" when putting or deleting. this resolve #1 

- Changed revision query string from "_rev" to "rev"